### PR TITLE
fix: More than one call to .gui caused more level synths spawned

### DIFF
--- a/GUI/AbstractGUIComponentCP.sc
+++ b/GUI/AbstractGUIComponentCP.sc
@@ -1,5 +1,5 @@
 AbstractGUIComponentCP {
-    classvar <>cmdPeriodActionsAdded = false;
+  classvar <>cmdPeriodActionsAdded = false;
 
   var window, <options;
 
@@ -30,14 +30,14 @@ AbstractGUIComponentCP {
   }
 
   setCmdPeriodActions {
-      this.class.cmdPeriodActionsAdded.not.if({
-          CmdPeriod.add({
-              AppClock.sched(0.1, {
-                  this.cmdPeriodAction;
-              });
-          });
-          this.class.cmdPeriodActionsAdded = true;
-      })
+    this.class.cmdPeriodActionsAdded.not.if({
+      CmdPeriod.add({
+        AppClock.sched(0.1, {
+          this.cmdPeriodAction;
+        });
+      });
+      this.class.cmdPeriodActionsAdded = true;
+    })
   }
 
   createLabel { arg text = "placeholder text", width = 280, height = 20; var label;

--- a/GUI/AbstractGUIComponentCP.sc
+++ b/GUI/AbstractGUIComponentCP.sc
@@ -1,8 +1,7 @@
+AbstractGUIComponentCP {
+    classvar <>cmdPeriodActionsAdded = false;
 
-
-AbstractGUIComponentCP { 
-
-  var window, <options; 
+  var window, <options;
 
   *new { arg window, options = ();
     ^super.newCopyArgs( window, options).init;
@@ -31,11 +30,14 @@ AbstractGUIComponentCP {
   }
 
   setCmdPeriodActions {
-    CmdPeriod.add({
-      AppClock.sched(0.1, {
-        this.cmdPeriodAction;
-      });
-    });
+      this.class.cmdPeriodActionsAdded.not.if({
+          CmdPeriod.add({
+              AppClock.sched(0.1, {
+                  this.cmdPeriodAction;
+              });
+          });
+          this.class.cmdPeriodActionsAdded = true;
+      })
   }
 
   createLabel { arg text = "placeholder text", width = 280, height = 20; var label;


### PR DESCRIPTION
This fixes the problem where several calls to `.gui` would result in several calls to `CmdPeriod.add` causing extra level synths to be spawned each time after cmdperiod. 

Verify it by running
```
s.plotTree;
CuePlayer.new().gui;
CuePlayer.new().gui;
```